### PR TITLE
[Feat5-FR8] Inital Commit for Restaurants to track Delivery

### DIFF
--- a/app/controllers/order_controller.py
+++ b/app/controllers/order_controller.py
@@ -77,3 +77,10 @@ def update_payment_status(order_id: int, request: PaymentUpdateRequest):
         "message": f"Payment {request.status}",
         "order": updated_order
     }
+
+@router.get("/restaurants/{restaurant_id}/track-delivery", response_model=List[TrackOrderResponse])
+def track_delivery_for_restaurant(restaurant_id: int):
+    """
+    Returns delivery tracking info for all orders of a restaurant.
+    """
+    return order_service.track_order_for_restaurant(restaurant_id)

--- a/app/database.py
+++ b/app/database.py
@@ -238,7 +238,6 @@ def get_incoming_orders_for_restaurant(restaurant_id: int):
         if order["restaurantId"] == restaurant_id
     ]
 
-
 def get_all_orders():
     """
     Returns all orders in memory.

--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -44,6 +44,28 @@ class OrderService:
             "minutesRemaining": minutes_remaining
         }
 
+    def track_order_for_restaurant(self, restaurant_id: int):
+        """
+        Returns delivery tracking info for all orders of a restaurant.
+        """
+        orders = database.get_incoming_orders_for_restaurant(restaurant_id)
+        tracking_info = []
+        for order in orders:
+            created_at = datetime.fromisoformat(order["createdAt"])
+            eta_minutes = order["estimatedDeliveryMinutes"]
+            estimated_arrival = datetime.fromisoformat(order["estimatedArrivalTime"])
+
+            elapsed_time = (datetime.now() - created_at).total_seconds() // 60
+            minutes_remaining = max(0, eta_minutes - elapsed_time)
+
+            tracking_info.append({
+                "orderId": order["orderId"],
+                "status": order["status"],
+                "estimatedArrivalTime": estimated_arrival.isoformat(),
+                "minutesRemaining": minutes_remaining
+            })
+        return tracking_info
+
     def update_order_status(self, order_id: int, new_status: str):
         """
         Updates the status of an order (e.g., from 'pending' to 'preparing').

--- a/tests/test_restaurant_track_delivery.py
+++ b/tests/test_restaurant_track_delivery.py
@@ -1,0 +1,119 @@
+"""Tests for restaurant delivery tracking."""
+from datetime import datetime, timedelta
+from fastapi.testclient import TestClient
+from app.main import app
+from app import database
+
+client = TestClient(app)
+
+def setup_module(module):  # pylint: disable=unused-argument
+    """
+    Setup function to reset order storage before each test
+    """
+    database.orders_map.clear()
+    database.NEXT_ORDER_ID = 1
+
+def test_track_delivery_for_restaurant_returns_tracking_info():
+    """
+    Restaurants should receive tracking info for all their orders.
+    """
+    now = datetime.now()
+
+    database.orders_map = {
+        1: {
+            "orderId": 1,
+            "restaurantId": 100,
+            "userId": 1,
+            "items": [1],
+            "status": "preparing",
+            "createdAt": (now - timedelta(minutes=10)).isoformat(),
+            "estimatedDeliveryMinutes": 40,
+            "estimatedArrivalTime": (now + timedelta(minutes=30)).isoformat(),
+            "payment_status": "pending",
+        },
+        2: {
+            "orderId": 2,
+            "restaurantId": 100,
+            "userId": 2,
+            "items": [2],
+            "status": "out-for-delivery",
+            "createdAt": (now - timedelta(minutes=20)).isoformat(),
+            "estimatedDeliveryMinutes": 35,
+            "estimatedArrivalTime": (now + timedelta(minutes=15)).isoformat(),
+            "payment_status": "pending",
+        },
+        3: {
+            "orderId": 3,
+            "restaurantId": 101,
+            "userId": 3,
+            "items": [3],
+            "status": "pending",
+            "createdAt": (now - timedelta(minutes=5)).isoformat(),
+            "estimatedDeliveryMinutes": 25,
+            "estimatedArrivalTime": (now + timedelta(minutes=20)).isoformat(),
+            "payment_status": "pending",
+        },
+    }
+
+    response = client.get("/orders/restaurants/100/track-delivery")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 2
+    assert data[0]["orderId"] == 1
+    assert data[0]["status"] == "preparing"
+    assert "estimatedArrivalTime" in data[0]
+    assert "minutesRemaining" in data[0]
+    assert data[1]["orderId"] == 2
+    assert data[1]["status"] == "out-for-delivery"
+    assert "estimatedArrivalTime" in data[1]
+    assert "minutesRemaining" in data[1]
+
+def test_track_delivery_for_restaurant_no_orders():
+    """
+    Should return empty list if restaurant has no orders.
+    """
+    database.orders_map.clear()
+
+    response = client.get("/orders/restaurants/999/track-delivery")
+    assert response.status_code == 200
+    data = response.json()
+    assert isinstance(data, list)
+    assert len(data) == 0
+
+def test_track_delivery_for_restaurant_excludes_other_restaurants_orders():
+    """
+    Should only return orders for the specified restaurant.
+    """
+    now = datetime.now()
+
+    database.orders_map = {
+        1: {
+            "orderId": 1,
+            "restaurantId": 100,
+            "userId": 1,
+            "items": [1],
+            "status": "preparing",
+            "createdAt": (now - timedelta(minutes=10)).isoformat(),
+            "estimatedDeliveryMinutes": 40,
+            "estimatedArrivalTime": (now + timedelta(minutes=30)).isoformat(),
+            "payment_status": "pending",
+        },
+        2: {
+            "orderId": 2,
+            "restaurantId": 101,
+            "userId": 2,
+            "items": [2],
+            "status": "out-for-delivery",
+            "createdAt": (now - timedelta(minutes=20)).isoformat(),
+            "estimatedDeliveryMinutes": 35,
+            "estimatedArrivalTime": (now + timedelta(minutes=15)).isoformat(),
+            "payment_status": "pending",
+        },
+    }
+
+    response = client.get("/orders/restaurants/100/track-delivery")
+    assert response.status_code == 200
+    data = response.json()
+    assert len(data) == 1
+    assert data[0]["orderId"] == 1
+    assert data[0]["status"] == "preparing"


### PR DESCRIPTION
resolves #25 
This PR adds the functionality to allow restaurants to track their order status.


The following changes were made:
1. Added a track_orders_for_restaurant function in order_service, which returns delivery info for all orders relating to a restaurant
2. Added a new route in  order_controller.py (track_delivery_for_restaurant)

Pleas let me know if there are any changes to be made. Thank you!
