### PR TITLE
[TEST]: add equivalence partitioning and prevent negative distance orders

### DIFF
--- a/app/services/order_service.py
+++ b/app/services/order_service.py
@@ -135,7 +135,10 @@ def calculate_total_cost_of_order(item_ids: List[int], distance_km: float,
     Calculates the total cost of the order (total food price + delivery fee).
     """
     food_total = 0.0
-
+    if distance_km < 0:
+        raise HTTPException(
+            status_code=400,
+            detail="Distance cannot be negative")
     for item_id in item_ids:
         item = database.get_menu_item_by_id(item_id)
         if item:

--- a/tests/test_order_cost.py
+++ b/tests/test_order_cost.py
@@ -62,3 +62,28 @@ def test_calculate_total_order_cost_item_not_found():
 
     assert "total_order_cost" in data
     assert data["total_order_cost"] == 91.47
+
+def test_partitioning_distance_total_cost():
+    """
+    Tests different values for distance_km.
+    """
+    response = client.post("/orders/calculate-total-cost", json={
+        "item_ids": [3, 44],
+        "distance_km": -5,
+        "time_minutes": 20
+    })
+    assert response.status_code== 400
+
+    response = client.post("/orders/calculate-total-cost", json={
+        "item_ids": [3, 44],
+        "distance_km": 0,
+        "time_minutes": 20
+    })
+    assert response.status_code == 200
+
+    response = client.post("/orders/calculate-total-cost", json={
+        "item_ids": [3, 44],
+        "distance_km": 2,
+        "time_minutes": 20
+    })
+    assert response.status_code == 200


### PR DESCRIPTION
`tests/test_order_cost.py:` Added `test_partitioning_distance_total_cost`.

Then noticed that logic backend didn't handle negative distances and still processed them so I changed the code in `order_service.py` to handle it and return 400 status_code