### PR TITLE
fix: align schemas, fix revenue calc, and update test payloads

### DIFF
--- a/app/database.py
+++ b/app/database.py
@@ -225,12 +225,18 @@ def create_order(user_id: int, restaurant_id: int, items: list, time_minutes: in
     estimated_delivery_minutes = 15 + 5 + time_minutes
     estimated_arrival_time = created_at + datetime.timedelta(
         minutes=estimated_delivery_minutes)
+    total_value = 0.0
+    for item_id in items:
+        item = get_menu_item_by_id(item_id)
+        if item:
+            total_value += item.get("price", 0.0)
 
     new_order = {
         "orderId": NEXT_ORDER_ID,
         "userId": user_id,
         "restaurantId": restaurant_id,
         "items": items,
+        "order_value": total_value,
         "status": OrderStatus.PENDING.value,
         "createdAt": created_at.isoformat(),
         "estimatedDeliveryMinutes": estimated_delivery_minutes,

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -77,13 +77,15 @@ class OrderResponse(BaseModel):
     """
     Schema for viewing incoming restaurant orders.
     """
-    order_id: int
-    restaurant_id: int
-    food_item: str
-    order_time: str
-    order_value: float
-    customer_id: int
+    orderId: int
+    restaurantId: int
+    userId: int
+    items: List[int] = []
+    order_value: float = 0.0
     status: str
+    payment_status: str = "pending"
+    createdAt: str | None = None
+    order_time: str | None = None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/tests/test_incoming_order.py
+++ b/tests/test_incoming_order.py
@@ -58,8 +58,8 @@ def test_view_incoming_orders_success():
     data = response.json()
 
     assert len(data) == 2
-    assert data[0]["restaurant_id"] == 100
-    assert data[1]["restaurant_id"] == 100
+    assert data[0]["restaurantId"] == 100
+    assert data[1]["restaurantId"] == 100
 
 
 def test_view_incoming_orders_empty():

--- a/tests/test_modify_cancel.py
+++ b/tests/test_modify_cancel.py
@@ -54,17 +54,17 @@ def test_cancel_order_too_late():
 def test_modify_order_success():
     """Test modifying an order that is still pending."""
 
-    payload = {"food_item": "Curly Fries", "order_value": 12.0}
+    payload = {"items": [99], "order_value": 12.0}
     response = client.put("/orders/1/modify", json=payload)
 
     assert response.status_code == 200
-    assert response.json()["food_item"] == "Curly Fries"
+    assert response.json()["items"] == [99]
     assert response.json()["order_value"] == 12.0
 
 def test_modify_order_too_late():
     """Test modifying an order that is already being prepared."""
 
-    payload = {"food_item": "Salad"}
+    payload = {"item": [50]}
     response = client.put("/orders/2/modify", json=payload)
 
     assert response.status_code == 400


### PR DESCRIPTION
`Schema Crash:` Fixed `schemas.py` so the `OrderResponse` variables `(orderId, createdAt, items)` perfectly match the keys in our database.

`Revenue Bug:` Updated `create_order` in `database.py` to actually add up the prices of the items and save the `order_value.` Before, it wasn't saving the price, so the restaurant revenue was always zero.

`Broken Tests:` Updated the hardcoded dummy data in `test_incoming_order.py` and `test_modify_cancel.py` to use the right variable names and lists so Pytest passes.